### PR TITLE
Fix mobile keyboard viewport layout

### DIFF
--- a/client-heroui/index.html
+++ b/client-heroui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/roomtalk-logo.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content" />
     <title>RoomTalk - Real-time Chat Rooms</title>
   </head>
   <body>

--- a/client-heroui/src/App.tsx
+++ b/client-heroui/src/App.tsx
@@ -1,29 +1,11 @@
 import { useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { MessagePage } from './pages/MessagePage';
+import { installAppViewportSizing } from './utils/appViewport';
 
 export default function App() {
   useEffect(() => {
-    const viewport = window.visualViewport;
-
-    const updateViewportHeight = () => {
-      const height = viewport?.height ?? window.innerHeight;
-      document.documentElement.style.setProperty('--app-height', `${height}px`);
-    };
-
-    updateViewportHeight();
-
-    window.addEventListener('resize', updateViewportHeight);
-    window.addEventListener('orientationchange', updateViewportHeight);
-    viewport?.addEventListener('resize', updateViewportHeight);
-    viewport?.addEventListener('scroll', updateViewportHeight);
-
-    return () => {
-      window.removeEventListener('resize', updateViewportHeight);
-      window.removeEventListener('orientationchange', updateViewportHeight);
-      viewport?.removeEventListener('resize', updateViewportHeight);
-      viewport?.removeEventListener('scroll', updateViewportHeight);
-    };
+    return installAppViewportSizing();
   }, []);
 
   return (

--- a/client-heroui/src/components/MessageInput.tsx
+++ b/client-heroui/src/components/MessageInput.tsx
@@ -592,7 +592,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({ roomId, username, av
         <div className="overflow-hidden rounded-[1.65rem] border border-[#dedbd0] bg-[#faf9f5] shadow-[0_0_0_1px_rgba(194,192,182,0.35)] dark:border-[#30302e] dark:bg-[#2a2a28]">
           {/* 编辑区域 */}
           <div
-            className="min-h-16 max-h-36 w-full overflow-y-auto px-4 pb-2 pt-4 text-sm leading-6 text-[#141413] dark:text-[#faf9f5]"
+            className="min-h-16 max-h-36 w-full overflow-y-auto px-4 pb-2 pt-4 text-base leading-6 text-[#141413] dark:text-[#faf9f5] sm:text-sm"
             contentEditable={!isSending && !isAiProcessing} // 禁用编辑区域当 AI 处理中
             onInput={parseEditorContent}
             onPaste={handlePaste}

--- a/client-heroui/src/index.css
+++ b/client-heroui/src/index.css
@@ -34,8 +34,15 @@ body,
 
 body {
   margin: 0;
+  position: fixed;
+  inset: 0;
   touch-action: manipulation;
   color: var(--rt-text);
+}
+
+#root {
+  position: fixed;
+  inset: 0;
 }
 
 .dark {
@@ -51,6 +58,7 @@ body {
 
 .app-shell {
   width: 100%;
+  height: 100vh;
   height: 100dvh;
   height: var(--app-height, 100dvh);
   overflow: hidden;

--- a/client-heroui/src/utils/appViewport.test.ts
+++ b/client-heroui/src/utils/appViewport.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { installAppViewportSizing } from './appViewport';
+
+const createVisualViewport = (initialHeight: number) => {
+  const target = new EventTarget();
+
+  return {
+    get height() {
+      return initialHeight;
+    },
+    set height(nextHeight: number) {
+      initialHeight = nextHeight;
+    },
+    addEventListener: target.addEventListener.bind(target),
+    removeEventListener: target.removeEventListener.bind(target),
+    dispatch(type: string) {
+      target.dispatchEvent(new Event(type));
+    },
+  };
+};
+
+const setVisualViewport = (viewport: ReturnType<typeof createVisualViewport> | undefined) => {
+  Object.defineProperty(window, 'visualViewport', {
+    configurable: true,
+    value: viewport,
+  });
+};
+
+describe('installAppViewportSizing', () => {
+  beforeEach(() => {
+    document.documentElement.style.removeProperty('--app-height');
+
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 800,
+    });
+
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setVisualViewport(undefined);
+  });
+
+  it('uses visualViewport height and updates it on visual viewport resize', () => {
+    const viewport = createVisualViewport(640);
+    setVisualViewport(viewport);
+
+    const cleanup = installAppViewportSizing();
+
+    expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('640px');
+
+    viewport.height = 420;
+    viewport.dispatch('resize');
+
+    expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('420px');
+
+    cleanup();
+
+    viewport.height = 360;
+    viewport.dispatch('resize');
+
+    expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('420px');
+  });
+
+  it('ignores visualViewport scroll events from mobile keyboard panning', () => {
+    const viewport = createVisualViewport(640);
+    setVisualViewport(viewport);
+
+    const cleanup = installAppViewportSizing();
+
+    viewport.height = 420;
+    viewport.dispatch('scroll');
+
+    expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('640px');
+
+    cleanup();
+  });
+
+  it('falls back to window.innerHeight when visualViewport is unavailable', () => {
+    setVisualViewport(undefined);
+
+    const cleanup = installAppViewportSizing();
+
+    expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('800px');
+
+    cleanup();
+  });
+});

--- a/client-heroui/src/utils/appViewport.ts
+++ b/client-heroui/src/utils/appViewport.ts
@@ -1,0 +1,46 @@
+const APP_HEIGHT_CSS_VAR = '--app-height';
+
+const getViewportHeight = (win: Window) => {
+  const visualHeight = win.visualViewport?.height;
+  const height =
+    typeof visualHeight === 'number' && Number.isFinite(visualHeight) && visualHeight > 0
+      ? visualHeight
+      : win.innerHeight;
+
+  return Math.max(1, Math.round(height));
+};
+
+export const installAppViewportSizing = (win: Window = window) => {
+  const root = win.document.documentElement;
+  const viewport = win.visualViewport;
+  let frameId: number | null = null;
+
+  const updateViewportHeight = () => {
+    frameId = null;
+    root.style.setProperty(APP_HEIGHT_CSS_VAR, `${getViewportHeight(win)}px`);
+  };
+
+  const scheduleViewportHeightUpdate = () => {
+    if (frameId !== null) {
+      win.cancelAnimationFrame(frameId);
+    }
+
+    frameId = win.requestAnimationFrame(updateViewportHeight);
+  };
+
+  scheduleViewportHeightUpdate();
+
+  win.addEventListener('resize', scheduleViewportHeightUpdate);
+  win.addEventListener('orientationchange', scheduleViewportHeightUpdate);
+  viewport?.addEventListener('resize', scheduleViewportHeightUpdate);
+
+  return () => {
+    win.removeEventListener('resize', scheduleViewportHeightUpdate);
+    win.removeEventListener('orientationchange', scheduleViewportHeightUpdate);
+    viewport?.removeEventListener('resize', scheduleViewportHeightUpdate);
+
+    if (frameId !== null) {
+      win.cancelAnimationFrame(frameId);
+    }
+  };
+};


### PR DESCRIPTION
## Summary
- Fix mobile keyboard viewport sizing by moving the app-height logic into a tested helper.
- Stop reacting to visualViewport scroll events that can be emitted during iOS keyboard panning.
- Pin body and root to the viewport and use a 16px mobile editor font to reduce iOS focus zoom/pan behavior.

## Root Cause
On mobile Safari-like browsers, focusing the contentEditable message input can pan the page while visualViewport events are also shrinking the app shell. That combination can leave a large blank region and push the message list out of the visible viewport.

## Validation
- npm test -- --run
- npm run build
- git diff --check origin/master...HEAD
