### PR TITLE
Fix mobile keyboard viewport offset

### DIFF
--- a/client-heroui/src/index.css
+++ b/client-heroui/src/index.css
@@ -4,6 +4,7 @@
 
 :root {
   --app-height: 100dvh;
+  --app-viewport-top: 0px;
   --rt-paper: #f5f4ed;
   --rt-ivory: #faf9f5;
   --rt-sand: #e8e6dc;
@@ -57,6 +58,10 @@ body {
 }
 
 .app-shell {
+  position: fixed;
+  top: var(--app-viewport-top, 0px);
+  left: 0;
+  right: 0;
   width: 100%;
   height: 100vh;
   height: 100dvh;

--- a/client-heroui/src/utils/appViewport.test.ts
+++ b/client-heroui/src/utils/appViewport.test.ts
@@ -3,7 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { installAppViewportSizing } from './appViewport';
 
-const createVisualViewport = (initialHeight: number) => {
+const createVisualViewport = (initialHeight: number, initialOffsetTop = 0) => {
   const target = new EventTarget();
 
   return {
@@ -12,6 +12,12 @@ const createVisualViewport = (initialHeight: number) => {
     },
     set height(nextHeight: number) {
       initialHeight = nextHeight;
+    },
+    get offsetTop() {
+      return initialOffsetTop;
+    },
+    set offsetTop(nextOffsetTop: number) {
+      initialOffsetTop = nextOffsetTop;
     },
     addEventListener: target.addEventListener.bind(target),
     removeEventListener: target.removeEventListener.bind(target),
@@ -31,6 +37,7 @@ const setVisualViewport = (viewport: ReturnType<typeof createVisualViewport> | u
 describe('installAppViewportSizing', () => {
   beforeEach(() => {
     document.documentElement.style.removeProperty('--app-height');
+    document.documentElement.style.removeProperty('--app-viewport-top');
 
     Object.defineProperty(window, 'innerHeight', {
       configurable: true,
@@ -56,30 +63,37 @@ describe('installAppViewportSizing', () => {
     const cleanup = installAppViewportSizing();
 
     expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('640px');
+    expect(document.documentElement.style.getPropertyValue('--app-viewport-top')).toBe('0px');
 
     viewport.height = 420;
+    viewport.offsetTop = 24;
     viewport.dispatch('resize');
 
     expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('420px');
+    expect(document.documentElement.style.getPropertyValue('--app-viewport-top')).toBe('24px');
 
     cleanup();
 
     viewport.height = 360;
+    viewport.offsetTop = 48;
     viewport.dispatch('resize');
 
     expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('420px');
+    expect(document.documentElement.style.getPropertyValue('--app-viewport-top')).toBe('24px');
   });
 
-  it('ignores visualViewport scroll events from mobile keyboard panning', () => {
+  it('updates visualViewport top offset on mobile keyboard panning without changing height', () => {
     const viewport = createVisualViewport(640);
     setVisualViewport(viewport);
 
     const cleanup = installAppViewportSizing();
 
     viewport.height = 420;
+    viewport.offsetTop = 180;
     viewport.dispatch('scroll');
 
     expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('640px');
+    expect(document.documentElement.style.getPropertyValue('--app-viewport-top')).toBe('180px');
 
     cleanup();
   });
@@ -90,6 +104,7 @@ describe('installAppViewportSizing', () => {
     const cleanup = installAppViewportSizing();
 
     expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('800px');
+    expect(document.documentElement.style.getPropertyValue('--app-viewport-top')).toBe('0px');
 
     cleanup();
   });

--- a/client-heroui/src/utils/appViewport.ts
+++ b/client-heroui/src/utils/appViewport.ts
@@ -1,4 +1,5 @@
 const APP_HEIGHT_CSS_VAR = '--app-height';
+const APP_VIEWPORT_TOP_CSS_VAR = '--app-viewport-top';
 
 const getViewportHeight = (win: Window) => {
   const visualHeight = win.visualViewport?.height;
@@ -10,36 +11,64 @@ const getViewportHeight = (win: Window) => {
   return Math.max(1, Math.round(height));
 };
 
+const getViewportTop = (win: Window) => {
+  const offsetTop = win.visualViewport?.offsetTop;
+
+  return Math.max(
+    0,
+    Math.round(typeof offsetTop === 'number' && Number.isFinite(offsetTop) ? offsetTop : 0)
+  );
+};
+
 export const installAppViewportSizing = (win: Window = window) => {
   const root = win.document.documentElement;
   const viewport = win.visualViewport;
   let frameId: number | null = null;
+  let hasPendingFrame = false;
+  let pendingUpdate: 'all' | 'top' = 'all';
 
-  const updateViewportHeight = () => {
+  const updateViewport = () => {
+    const updateKind = pendingUpdate;
+    hasPendingFrame = false;
     frameId = null;
-    root.style.setProperty(APP_HEIGHT_CSS_VAR, `${getViewportHeight(win)}px`);
+
+    if (updateKind === 'all') {
+      root.style.setProperty(APP_HEIGHT_CSS_VAR, `${getViewportHeight(win)}px`);
+    }
+
+    root.style.setProperty(APP_VIEWPORT_TOP_CSS_VAR, `${getViewportTop(win)}px`);
   };
 
-  const scheduleViewportHeightUpdate = () => {
-    if (frameId !== null) {
+  const scheduleViewportUpdate = (updateKind: 'all' | 'top') => {
+    if (!hasPendingFrame || updateKind === 'all') {
+      pendingUpdate = updateKind;
+    }
+
+    if (hasPendingFrame && frameId !== null) {
       win.cancelAnimationFrame(frameId);
     }
 
-    frameId = win.requestAnimationFrame(updateViewportHeight);
+    hasPendingFrame = true;
+    frameId = win.requestAnimationFrame(updateViewport);
   };
 
-  scheduleViewportHeightUpdate();
+  const scheduleFullViewportUpdate = () => scheduleViewportUpdate('all');
+  const scheduleViewportTopUpdate = () => scheduleViewportUpdate('top');
 
-  win.addEventListener('resize', scheduleViewportHeightUpdate);
-  win.addEventListener('orientationchange', scheduleViewportHeightUpdate);
-  viewport?.addEventListener('resize', scheduleViewportHeightUpdate);
+  scheduleFullViewportUpdate();
+
+  win.addEventListener('resize', scheduleFullViewportUpdate);
+  win.addEventListener('orientationchange', scheduleFullViewportUpdate);
+  viewport?.addEventListener('resize', scheduleFullViewportUpdate);
+  viewport?.addEventListener('scroll', scheduleViewportTopUpdate);
 
   return () => {
-    win.removeEventListener('resize', scheduleViewportHeightUpdate);
-    win.removeEventListener('orientationchange', scheduleViewportHeightUpdate);
-    viewport?.removeEventListener('resize', scheduleViewportHeightUpdate);
+    win.removeEventListener('resize', scheduleFullViewportUpdate);
+    win.removeEventListener('orientationchange', scheduleFullViewportUpdate);
+    viewport?.removeEventListener('resize', scheduleFullViewportUpdate);
+    viewport?.removeEventListener('scroll', scheduleViewportTopUpdate);
 
-    if (frameId !== null) {
+    if (hasPendingFrame && frameId !== null) {
       win.cancelAnimationFrame(frameId);
     }
   };


### PR DESCRIPTION
## Summary
- Track `visualViewport.offsetTop` separately from viewport height.
- Keep the app shell fixed to the shifted visual viewport during iOS keyboard panning.
- Extend viewport sizing tests to cover keyboard scroll/offset behavior without changing app height.

## Why
The first mobile keyboard fix kept height stable but ignored iOS visual viewport offset changes. On Safari-like mobile browsers, focusing the composer can move the visual viewport and leave the app shell visually offset, producing a large blank area above the keyboard.

## Validation
- npm test -- appViewport.test.ts
- npm test -- --run
- npm run build
- git diff --check
