### PR TITLE
[codex] Fix mobile composer reflow

### DIFF
--- a/client-heroui/e2e/mobile-core.mobile.spec.ts
+++ b/client-heroui/e2e/mobile-core.mobile.spec.ts
@@ -28,7 +28,7 @@ test('creates a room and sends a message on mobile', async ({ page, context }) =
   await sendTextMessage(page, message);
 });
 
-test('keeps the chat scroller expanded above the mobile input panel', async ({ page, context, request }) => {
+test('keeps the chat scroller stable while the mobile keyboard and input height change', async ({ page, context, request }) => {
   const clientId = await seedClient(context);
   const room = await createRoomViaApi(request, clientId, shortName('mobile-layout'));
 
@@ -43,15 +43,17 @@ test('keeps the chat scroller expanded above the mobile input panel', async ({ p
   await expect(inputPanel).toBeVisible();
   await expect(bottomNav).toBeVisible();
 
-  const layout = await page.evaluate(() => {
+  const readLayout = () => page.evaluate(() => {
     const rectFor = (testId: string) => {
       const element = document.querySelector(`[data-testid="${testId}"]`);
       if (!element) throw new Error(`Missing ${testId}`);
       const rect = element.getBoundingClientRect();
+      const styles = getComputedStyle(element);
       return {
         top: rect.top,
         bottom: rect.bottom,
         height: rect.height,
+        paddingBottom: styles.paddingBottom,
       };
     };
 
@@ -63,7 +65,21 @@ test('keeps the chat scroller expanded above the mobile input panel', async ({ p
     };
   });
 
-  expect(layout.messageList.height).toBeGreaterThan(layout.viewportHeight * 0.2);
-  expect(layout.inputPanel.top).toBeGreaterThanOrEqual(layout.messageList.bottom - 1);
-  expect(layout.bottomNav.top - layout.inputPanel.bottom).toBeLessThanOrEqual(4);
+  const baseline = await readLayout();
+
+  await page.getByTestId('message-editor').click();
+  await page.evaluate(() => {
+    document.documentElement.style.setProperty('--app-keyboard-inset', '324px');
+  });
+  await page.keyboard.insertText('line 1\nline 2\nline 3\nline 4\nline 5\nline 6');
+
+  const keyboardOpen = await readLayout();
+
+  expect(baseline.messageList.height).toBeGreaterThan(baseline.viewportHeight * 0.2);
+  expect(keyboardOpen.messageList.top).toBeCloseTo(baseline.messageList.top, 1);
+  expect(keyboardOpen.messageList.bottom).toBeCloseTo(baseline.messageList.bottom, 1);
+  expect(keyboardOpen.messageList.height).toBeCloseTo(baseline.messageList.height, 1);
+  expect(keyboardOpen.messageList.paddingBottom).toBe(baseline.messageList.paddingBottom);
+  expect(keyboardOpen.inputPanel.bottom).toBeLessThan(baseline.inputPanel.bottom);
+  expect(keyboardOpen.inputPanel.height).toBeGreaterThan(baseline.inputPanel.height);
 });

--- a/client-heroui/src/components/ChatRoomView.tsx
+++ b/client-heroui/src/components/ChatRoomView.tsx
@@ -46,9 +46,9 @@ export const ChatRoomView: React.FC<ChatRoomViewProps> = ({
 }) => {
   const { t } = useTranslation();
   const [replyToMessage, setReplyToMessage] = React.useState<Message | null>(null);
+  const chatBodyRef = React.useRef<HTMLDivElement>(null);
   const composerRef = React.useRef<HTMLDivElement>(null);
   const messageListRef = React.useRef<MessageListHandle>(null);
-  const [composerHeight, setComposerHeight] = React.useState(96);
   const [showScrollButton, setShowScrollButton] = React.useState(false);
 
   React.useEffect(() => {
@@ -58,10 +58,11 @@ export const ChatRoomView: React.FC<ChatRoomViewProps> = ({
 
   React.useLayoutEffect(() => {
     const el = composerRef.current;
+    const body = chatBodyRef.current;
     if (!el) return;
 
     const update = () => {
-      setComposerHeight(Math.ceil(el.getBoundingClientRect().height));
+      body?.style.setProperty('--rt-composer-height', `${Math.ceil(el.getBoundingClientRect().height)}px`);
     };
 
     update();
@@ -96,12 +97,11 @@ export const ChatRoomView: React.FC<ChatRoomViewProps> = ({
         clientId={clientId}
       />
 
-      <div className="relative min-h-0 w-full flex-1 overflow-hidden">
+      <div ref={chatBodyRef} className="relative min-h-0 w-full flex-1 overflow-hidden [--rt-composer-height:132px]">
         <MessageList
           ref={messageListRef}
           roomId={currentRoom.id}
           onReply={setReplyToMessage}
-          bottomPaddingPx={composerHeight + 12}
           onScrollButtonVisibilityChange={setShowScrollButton}
         />
 
@@ -113,7 +113,7 @@ export const ChatRoomView: React.FC<ChatRoomViewProps> = ({
             size="sm"
             radius="full"
             className="absolute left-1/2 z-40 -translate-x-1/2 bg-[#30302e] text-[#faf9f5] shadow-[0_0_0_1px_rgba(194,192,182,0.7),0_10px_24px_rgba(20,20,19,0.16)] dark:bg-[#faf9f5] dark:text-[#141413]"
-            style={{ bottom: composerHeight + 16 }}
+            style={{ bottom: 'calc(max(0px, calc(var(--app-keyboard-inset, 0px) - var(--rt-bottom-nav-height, 0px))) + var(--rt-composer-height, 132px) + 16px)' }}
             aria-label={t('scrollToBottom')}
             onPress={() => messageListRef.current?.scrollToBottom('smooth')}
           >
@@ -124,7 +124,8 @@ export const ChatRoomView: React.FC<ChatRoomViewProps> = ({
         <div
           ref={composerRef}
           data-testid="message-input-panel"
-          className="absolute inset-x-0 bottom-0 z-30 border-t border-[#dedbd0] bg-[#faf9f5]/92 p-2 backdrop-blur-md dark:border-[#30302e] dark:bg-[#1d1d1b]/92 md:p-3"
+          className="absolute inset-x-0 z-30 border-t border-[#dedbd0] bg-[#faf9f5]/92 p-2 backdrop-blur-md dark:border-[#30302e] dark:bg-[#1d1d1b]/92 md:p-3"
+          style={{ bottom: 'max(0px, calc(var(--app-keyboard-inset, 0px) - var(--rt-bottom-nav-height, 0px)))' }}
         >
           <MessageInput
             roomId={currentRoom.id}

--- a/client-heroui/src/components/MessageInputAIControls.tsx
+++ b/client-heroui/src/components/MessageInputAIControls.tsx
@@ -301,6 +301,7 @@ export const MessageInputAIControls: React.FC<MessageInputAIControlsProps> = ({
               onPress={onAskAI}
               isLoading={isAiProcessing}
               isDisabled={isSending}
+              aria-label={t('askAI')}
               className="h-8 w-8 min-w-8 rounded-full bg-[#30302e] px-0 text-[#faf9f5] dark:bg-[#faf9f5] dark:text-[#141413] sm:h-9 sm:w-auto sm:min-w-9 sm:px-3"
             >
               <Icon icon={selectedRole.icon} className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
@@ -316,6 +317,7 @@ export const MessageInputAIControls: React.FC<MessageInputAIControlsProps> = ({
               size="sm"
               isLoading={isSending}
               isDisabled={isSending || isAiProcessing || (!currentInputText.trim() && imageCount === 0)}
+              aria-label={t('send')}
               className="h-8 w-8 min-w-8 rounded-full bg-[#c96442] px-0 text-[#faf9f5] shadow-[0_0_0_1px_#c96442] sm:h-9 sm:w-auto sm:min-w-9 sm:px-3"
             >
               <Icon icon="lucide:arrow-up" className="h-3.5 w-3.5 sm:h-4 sm:w-4" />

--- a/client-heroui/src/components/MessageList.tsx
+++ b/client-heroui/src/components/MessageList.tsx
@@ -28,6 +28,7 @@ interface MessageListProps {
   roomId: string;
   onReply: (message: Message) => void;
   bottomPaddingPx?: number;
+  bottomPadding?: string;
   onScrollButtonVisibilityChange?: (isVisible: boolean) => void;
 }
 
@@ -38,7 +39,8 @@ export interface MessageListHandle {
 export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
   roomId,
   onReply,
-  bottomPaddingPx = 16,
+  bottomPaddingPx,
+  bottomPadding,
   onScrollButtonVisibilityChange,
 }, ref) => {
   const { t } = useTranslation();
@@ -261,7 +263,7 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
         data-testid="message-list-scroll"
         ref={containerRef}
         className="relative flex h-full w-full flex-col overflow-y-auto bg-[#f5f4ed] p-3 dark:bg-[#141413]"
-        style={{ paddingBottom: bottomPaddingPx }}
+        style={{ paddingBottom: bottomPadding ?? (bottomPaddingPx ? `${bottomPaddingPx}px` : 'var(--rt-message-list-bottom-padding, 180px)') }}
         onScroll={handleScroll}
       >
         <div className="sticky top-0 z-20 mb-2 flex justify-end">

--- a/client-heroui/src/index.css
+++ b/client-heroui/src/index.css
@@ -3,8 +3,11 @@
 @tailwind utilities;
 
 :root {
-  --app-height: 100dvh;
+  --app-height: 100svh;
   --app-viewport-top: 0px;
+  --app-keyboard-inset: 0px;
+  --rt-bottom-nav-height: calc(3.3125rem + max(env(safe-area-inset-bottom), 0.5rem));
+  --rt-message-list-bottom-padding: 240px;
   --rt-paper: #f5f4ed;
   --rt-ivory: #faf9f5;
   --rt-sand: #e8e6dc;
@@ -59,15 +62,17 @@ body {
 
 .app-shell {
   position: fixed;
-  top: var(--app-viewport-top, 0px);
+  top: 0;
   left: 0;
   right: 0;
   width: 100%;
   height: 100vh;
-  height: 100dvh;
-  height: var(--app-height, 100dvh);
+  height: 100svh;
+  height: var(--app-height, 100svh);
   overflow: hidden;
   background: var(--rt-paper);
+  transform: translate3d(0, var(--app-viewport-top, 0px), 0);
+  will-change: transform;
 }
 
 .dark .app-shell {
@@ -80,6 +85,13 @@ body {
 
 .safe-top {
   padding-top: max(env(safe-area-inset-top), 0rem);
+}
+
+@media (min-width: 768px) {
+  :root {
+    --rt-bottom-nav-height: 0px;
+    --rt-message-list-bottom-padding: 180px;
+  }
 }
 
 .roomtalk-ring {

--- a/client-heroui/src/utils/appViewport.test.ts
+++ b/client-heroui/src/utils/appViewport.test.ts
@@ -38,6 +38,8 @@ describe('installAppViewportSizing', () => {
   beforeEach(() => {
     document.documentElement.style.removeProperty('--app-height');
     document.documentElement.style.removeProperty('--app-viewport-top');
+    document.documentElement.style.removeProperty('--app-keyboard-inset');
+    document.body.innerHTML = '';
 
     Object.defineProperty(window, 'innerHeight', {
       configurable: true,
@@ -56,21 +58,40 @@ describe('installAppViewportSizing', () => {
     setVisualViewport(undefined);
   });
 
-  it('uses visualViewport height and updates it on visual viewport resize', () => {
+  const focusEditable = () => {
+    const editor = document.createElement('input');
+    document.body.appendChild(editor);
+    editor.focus();
+    return editor;
+  };
+
+  it('uses a stable layout height and initializes keyboard vars', () => {
     const viewport = createVisualViewport(640);
     setVisualViewport(viewport);
 
     const cleanup = installAppViewportSizing();
 
-    expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('640px');
+    expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('800px');
     expect(document.documentElement.style.getPropertyValue('--app-viewport-top')).toBe('0px');
+    expect(document.documentElement.style.getPropertyValue('--app-keyboard-inset')).toBe('0px');
+
+    cleanup();
+  });
+
+  it('keeps app height stable when the visual viewport shrinks around a focused editor', () => {
+    const viewport = createVisualViewport(640);
+    setVisualViewport(viewport);
+
+    const cleanup = installAppViewportSizing();
+    focusEditable();
 
     viewport.height = 420;
     viewport.offsetTop = 24;
     viewport.dispatch('resize');
 
-    expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('420px');
+    expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('800px');
     expect(document.documentElement.style.getPropertyValue('--app-viewport-top')).toBe('24px');
+    expect(document.documentElement.style.getPropertyValue('--app-keyboard-inset')).toBe('380px');
 
     cleanup();
 
@@ -78,22 +99,25 @@ describe('installAppViewportSizing', () => {
     viewport.offsetTop = 48;
     viewport.dispatch('resize');
 
-    expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('420px');
+    expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('800px');
     expect(document.documentElement.style.getPropertyValue('--app-viewport-top')).toBe('24px');
+    expect(document.documentElement.style.getPropertyValue('--app-keyboard-inset')).toBe('380px');
   });
 
-  it('updates visualViewport top offset on mobile keyboard panning without changing height', () => {
+  it('updates keyboard overlay vars on mobile keyboard panning without changing height', () => {
     const viewport = createVisualViewport(640);
     setVisualViewport(viewport);
 
     const cleanup = installAppViewportSizing();
+    focusEditable();
 
     viewport.height = 420;
     viewport.offsetTop = 180;
     viewport.dispatch('scroll');
 
-    expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('640px');
+    expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('800px');
     expect(document.documentElement.style.getPropertyValue('--app-viewport-top')).toBe('180px');
+    expect(document.documentElement.style.getPropertyValue('--app-keyboard-inset')).toBe('380px');
 
     cleanup();
   });
@@ -105,6 +129,7 @@ describe('installAppViewportSizing', () => {
 
     expect(document.documentElement.style.getPropertyValue('--app-height')).toBe('800px');
     expect(document.documentElement.style.getPropertyValue('--app-viewport-top')).toBe('0px');
+    expect(document.documentElement.style.getPropertyValue('--app-keyboard-inset')).toBe('0px');
 
     cleanup();
   });

--- a/client-heroui/src/utils/appViewport.ts
+++ b/client-heroui/src/utils/appViewport.ts
@@ -1,14 +1,15 @@
 const APP_HEIGHT_CSS_VAR = '--app-height';
 const APP_VIEWPORT_TOP_CSS_VAR = '--app-viewport-top';
+const APP_KEYBOARD_INSET_CSS_VAR = '--app-keyboard-inset';
+
+const getFinitePositiveNumber = (value: number | undefined, fallback: number) => {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+};
 
 const getViewportHeight = (win: Window) => {
-  const visualHeight = win.visualViewport?.height;
-  const height =
-    typeof visualHeight === 'number' && Number.isFinite(visualHeight) && visualHeight > 0
-      ? visualHeight
-      : win.innerHeight;
-
-  return Math.max(1, Math.round(height));
+  return Math.max(1, Math.round(getFinitePositiveNumber(win.innerHeight, 1)));
 };
 
 const getViewportTop = (win: Window) => {
@@ -20,12 +21,37 @@ const getViewportTop = (win: Window) => {
   );
 };
 
+const isEditableElement = (element: Element | null) => {
+  if (!(element instanceof HTMLElement)) {
+    return false;
+  }
+
+  return (
+    element.isContentEditable ||
+    element.getAttribute('contenteditable') === 'true' ||
+    element.tagName === 'TEXTAREA' ||
+    element.tagName === 'INPUT'
+  );
+};
+
+const getKeyboardInset = (win: Window, layoutHeight: number) => {
+  if (!isEditableElement(win.document.activeElement)) {
+    return 0;
+  }
+
+  const visualHeight = getFinitePositiveNumber(win.visualViewport?.height, layoutHeight);
+
+  return Math.max(0, Math.round(layoutHeight - visualHeight));
+};
+
 export const installAppViewportSizing = (win: Window = window) => {
   const root = win.document.documentElement;
   const viewport = win.visualViewport;
   let frameId: number | null = null;
   let hasPendingFrame = false;
-  let pendingUpdate: 'all' | 'top' = 'all';
+  let pendingUpdate: 'all' | 'keyboard' = 'all';
+  let layoutHeight = getViewportHeight(win);
+  let layoutWidth = Math.max(1, Math.round(getFinitePositiveNumber(win.innerWidth, 1)));
 
   const updateViewport = () => {
     const updateKind = pendingUpdate;
@@ -33,13 +59,24 @@ export const installAppViewportSizing = (win: Window = window) => {
     frameId = null;
 
     if (updateKind === 'all') {
-      root.style.setProperty(APP_HEIGHT_CSS_VAR, `${getViewportHeight(win)}px`);
+      const nextWidth = Math.max(1, Math.round(getFinitePositiveNumber(win.innerWidth, layoutWidth)));
+      const nextHeight = getViewportHeight(win);
+
+      if (nextWidth !== layoutWidth || !isEditableElement(win.document.activeElement)) {
+        layoutHeight = nextHeight;
+        layoutWidth = nextWidth;
+      } else {
+        layoutHeight = Math.max(layoutHeight, nextHeight);
+      }
+
+      root.style.setProperty(APP_HEIGHT_CSS_VAR, `${layoutHeight}px`);
     }
 
     root.style.setProperty(APP_VIEWPORT_TOP_CSS_VAR, `${getViewportTop(win)}px`);
+    root.style.setProperty(APP_KEYBOARD_INSET_CSS_VAR, `${getKeyboardInset(win, layoutHeight)}px`);
   };
 
-  const scheduleViewportUpdate = (updateKind: 'all' | 'top') => {
+  const scheduleViewportUpdate = (updateKind: 'all' | 'keyboard') => {
     if (!hasPendingFrame || updateKind === 'all') {
       pendingUpdate = updateKind;
     }
@@ -53,20 +90,24 @@ export const installAppViewportSizing = (win: Window = window) => {
   };
 
   const scheduleFullViewportUpdate = () => scheduleViewportUpdate('all');
-  const scheduleViewportTopUpdate = () => scheduleViewportUpdate('top');
+  const scheduleKeyboardViewportUpdate = () => scheduleViewportUpdate('keyboard');
 
   scheduleFullViewportUpdate();
 
   win.addEventListener('resize', scheduleFullViewportUpdate);
   win.addEventListener('orientationchange', scheduleFullViewportUpdate);
-  viewport?.addEventListener('resize', scheduleFullViewportUpdate);
-  viewport?.addEventListener('scroll', scheduleViewportTopUpdate);
+  viewport?.addEventListener('resize', scheduleKeyboardViewportUpdate);
+  viewport?.addEventListener('scroll', scheduleKeyboardViewportUpdate);
+  win.document.addEventListener('focusin', scheduleKeyboardViewportUpdate);
+  win.document.addEventListener('focusout', scheduleKeyboardViewportUpdate);
 
   return () => {
     win.removeEventListener('resize', scheduleFullViewportUpdate);
     win.removeEventListener('orientationchange', scheduleFullViewportUpdate);
-    viewport?.removeEventListener('resize', scheduleFullViewportUpdate);
-    viewport?.removeEventListener('scroll', scheduleViewportTopUpdate);
+    viewport?.removeEventListener('resize', scheduleKeyboardViewportUpdate);
+    viewport?.removeEventListener('scroll', scheduleKeyboardViewportUpdate);
+    win.document.removeEventListener('focusin', scheduleKeyboardViewportUpdate);
+    win.document.removeEventListener('focusout', scheduleKeyboardViewportUpdate);
 
     if (hasPendingFrame && frameId !== null) {
       win.cancelAnimationFrame(frameId);


### PR DESCRIPTION
## Summary

- Keep the app shell height stable when the mobile visual viewport changes around the keyboard.
- Move the composer and scroll-to-bottom button using overlay CSS variables instead of resizing the message list.
- Add mobile layout coverage that verifies the message scroller stays stable while keyboard inset and multiline input height change.
- Add accessible labels to mobile icon-only AI/send buttons.

## Validation

- `npm test -- appViewport.test.ts`
- `E2E_SERVER_PORT=3312 E2E_CLIENT_PORT=3311 npm run test:e2e -- --project=mobile-chromium mobile-core.mobile.spec.ts`
- `npm test -- --run`
- `npm run build`
